### PR TITLE
adjust timeout to pass siege test

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -18,9 +18,6 @@ class Client {
         ~Client();
 
         /*relate to internal server*/
-        unsigned long       getServerHost();
-        int                 getServerPort();
-        void                setServer(const Server& serv);
         void                setSocket(int newsock);
 
         /*related to request and response*/

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -40,7 +40,6 @@ class ServerManager {
         void                    addSet(int fd, fd_set* set);
         void                    removeSet(int fd, fd_set* set);
         void                    checkTimeout();
-        void                    assignServer(Client &c);
         void                    writeCgi(int write_fd, CgiHandler& cgi);
         void                    readCgi(int read_fd, CgiHandler& cgi);
 };

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -21,6 +21,7 @@ Client::Client(Client const &cli): _serv(cli._serv)
         this->req = cli.req;
         this->resp = cli.resp;
         _raw_request = cli._raw_request;
+        _time_stamp = cli.getTime();
     }
 }
 
@@ -32,27 +33,13 @@ Client &Client::operator=(Client const &cli)
         this->req = cli.req;
         this->resp = cli.resp;
         _raw_request = cli._raw_request;
+        _time_stamp = cli.getTime();
     }
 
     return (*this);
 }
 
 Client::~Client() {}
-
-unsigned long Client::getServerHost()
-{
-    return this->_serv.getHost();
-}
-
-int     Client::getServerPort()
-{
-    return this->_serv.getPort();
-}
-
-void    Client::setServer(const Server& serv)
-{
-    this->_serv = serv;
-}
 
 void    Client::setSocket(int newsock)
 {

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -158,7 +158,7 @@ void    ServerManager::acceptConnection(int server_fd)
     socklen_t           client_addr_len = sizeof(client_addr);
     int                 client_fd;
     Client              new_client(_servers_map[server_fd]);
-    char                buf[INET_ADDRSTRLEN];
+    //char                buf[INET_ADDRSTRLEN];
 
     if (!_servers_map.count(server_fd))
     {
@@ -391,8 +391,6 @@ void    ServerManager::checkTimeout()
 {
     for (std::map<int, Client>::iterator cit = _clients_map.begin(); cit != _clients_map.end(); cit++)
     {
-        struct timeval  sm_curr;
-        gettimeofday(&sm_curr, NULL);
         if (time(NULL) - cit->second.getTime() > CONNECTION_TIMEOUT)
         {
             //Logger::logMsg(YELLOW, CONSOLE_OUTPUT, "Client %d Timeout, Closing Connection..", cit->first);


### PR DESCRIPTION
ServerManager.hpp
-remove assignServer: not needed
ServerManager.cpp
-remove timeval struct at ServerManager::checkTimeout(): not use
Client.hpp
-remove ever function related to server: not used
Client.cpp
-Same as hpp, but add this->_time_stamp = copy.getTime() for copy constructor and assignment operator